### PR TITLE
IE11 and Win NT improvements

### DIFF
--- a/lib/device_wizard.rb
+++ b/lib/device_wizard.rb
@@ -2,6 +2,8 @@ require "device_wizard/version"
 
 module DeviceWizard
 
+  UNKNOWN = 'Unknown'.freeze
+
   class DeviceType
     DESKTOP='desktop'
     TABLET='tablet'
@@ -42,6 +44,10 @@ module DeviceWizard
       @os_resolvers.push(IOSResolver.new)
       @os_resolvers.push(MacResolver.new)
       @os_resolvers.push(WindowsResolver.new)
+    end
+
+    def unknown
+      UNKNOWN
     end
 
     def get_device_type(user_agent)
@@ -141,8 +147,8 @@ module DeviceWizard
     attr_accessor :version
 
     def initialize
-      @name = 'Unknown'
-      @version = 'Unknown'
+      @name = UNKNOWN
+      @version = UNKNOWN
     end
   end
 
@@ -153,7 +159,7 @@ module DeviceWizard
 
     def get_version(user_agent)
       user_agent.downcase!
-      result = 'Unknown'
+      result = UNKNOWN
 
       if REGEX =~ user_agent
         result = $1
@@ -181,7 +187,7 @@ module DeviceWizard
 
     def get_version(user_agent)
       user_agent.downcase!
-      result = 'Unknown'
+      result = UNKNOWN
 
       if REGEX =~ user_agent
         result = $1
@@ -211,7 +217,7 @@ module DeviceWizard
 
     def get_version(user_agent)
       user_agent.downcase!
-      result = 'Unknown'
+      result = UNKNOWN
 
       if REGEX =~ user_agent
         result = $1
@@ -245,7 +251,7 @@ module DeviceWizard
 
     def get_version(user_agent)
       user_agent.downcase!
-      result = 'Unknown'
+      result = UNKNOWN
 
       if REGEX =~ user_agent
         result = $1
@@ -282,7 +288,7 @@ module DeviceWizard
 
     def get_version(user_agent)
       user_agent.downcase!
-      result = 'Unknown'
+      result = UNKNOWN
 
       if REGEX =~ user_agent
         result = $1
@@ -313,7 +319,7 @@ module DeviceWizard
 
     def get_version(user_agent)
       user_agent.downcase!
-      result = 'Unknown'
+      result = UNKNOWN
 
       if REGEX =~ user_agent
         result = $1
@@ -337,7 +343,7 @@ module DeviceWizard
         return 'IPhone'
       end
 
-      return 'Unknown'
+      return UNKNOWN
     end
 
     def identify(user_agent)
@@ -367,7 +373,7 @@ module DeviceWizard
 
     def get_version(user_agent)
       user_agent.downcase!
-      result = 'Unknown'
+      result = UNKNOWN
 
       if REGEX =~ user_agent
         result = $1
@@ -400,7 +406,7 @@ module DeviceWizard
 
     def get_version(user_agent)
       user_agent.downcase!
-      result = 'Unknown'
+      result = UNKNOWN
 
       if REGEX =~ user_agent
         if NTVERSION.index($1)

--- a/lib/device_wizard.rb
+++ b/lib/device_wizard.rb
@@ -204,9 +204,10 @@ module DeviceWizard
   end
 
   class InternetExplorerResolver
-
     KEYWORD = 'msie'
+    KEYWORD2 = ' rv:'
     REGEX = Regexp.new('msie ([0-9]+.[0-9])')
+    REGEX2 = Regexp.new('rv:([0-9]+.[0-9])')
 
     def get_version(user_agent)
       user_agent.downcase!
@@ -215,13 +216,18 @@ module DeviceWizard
       if REGEX =~ user_agent
         result = $1
       end
+      if REGEX2 =~ user_agent
+        result = $1
+      end
     end
 
     def identify(user_agent)
       user_agent.downcase!
 
       if !user_agent.include? KEYWORD
-        return nil
+        if !user_agent.include? KEYWORD2
+          return nil
+        end
       end
 
       result = BrowserDetails.new
@@ -389,13 +395,19 @@ module DeviceWizard
 
     KEYWORD = 'windows nt'
     REGEX = Regexp.new('windows nt ([0-9]{1,}[\.0-9]{0,})')
+    NTVERSION = [ '4.0', '5.0', '5.01', '5.1', '5.2', '6.0', '6.1', '6.2', '6.3' ]
+    NTNAME    = [ 'NT 4.0', '2000', '2000 SP1', 'XP', 'XP x64', 'Vista', '7', '8', '8.1' ]
 
     def get_version(user_agent)
       user_agent.downcase!
       result = 'Unknown'
 
       if REGEX =~ user_agent
-        result = $1
+        if NTVERSION.index($1)
+          result = NTNAME[NTVERSION.index($1)]
+        else
+          result = $1
+        end
       end
     end
 
@@ -413,6 +425,5 @@ module DeviceWizard
     end
 
   end
-
 
 end

--- a/lib/device_wizard/version.rb
+++ b/lib/device_wizard/version.rb
@@ -1,3 +1,3 @@
 module DeviceWizard
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Add IE11 detection and return correct Win NT OS name rather than internal version number
