### PR TITLE
Fix regex to allow for firefox also fixes version numbers

### DIFF
--- a/lib/device_wizard/resolvers/mac.rb
+++ b/lib/device_wizard/resolvers/mac.rb
@@ -5,7 +5,7 @@ module DeviceWizard
     class Mac < Base
       NAME = 'Mac OSX'
       KEYWORD = 'intel mac os x'
-      REGEX = Regexp.new('(intel mac os x (?:[0-9]+[._]?){1,3})')
+      REGEX = Regexp.new('(?:intel mac os x (([0-9]+[._]?){1,3}))')
 
       def get_version(user_agent)
         result = super(user_agent)

--- a/lib/device_wizard/resolvers/mac.rb
+++ b/lib/device_wizard/resolvers/mac.rb
@@ -5,7 +5,7 @@ module DeviceWizard
     class Mac < Base
       NAME = 'Mac OSX'
       KEYWORD = 'intel mac os x'
-      REGEX = Regexp.new('intel mac os x ([0-9]+_[0-9])')
+      REGEX = Regexp.new('(intel mac os x (?:[0-9]+[._]?){1,3})')
 
       def get_version(user_agent)
         result = super(user_agent)

--- a/lib/device_wizard/version.rb
+++ b/lib/device_wizard/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeviceWizard
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/device_wizard/browser_details_spec.rb
+++ b/spec/device_wizard/browser_details_spec.rb
@@ -4,12 +4,20 @@ describe DeviceWizard::UserAgentDetector do
 
   context 'Browser' do
 
-    it 'should correctly identify a firefox browser' do
+    it 'should correctly identify a firefox (windows) browser' do
 
       user_agent = "Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0";
       browser = subject.get_browser(user_agent)
       expect(browser.name).to eq('Firefox')
       expect(browser.version).to eq('31.0')
+    end
+
+    it 'should correctly identify a firefox (mac) browser' do
+
+      user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:71.0) Gecko/20100101 Firefox/71.0"
+      browser = subject.get_browser(user_agent)
+      expect(browser.name).to eq('Firefox')
+      expect(browser.version).to eq('71.0')
     end
 
     it 'should correctly identify a google chrome browser' do

--- a/spec/device_wizard/os_details_spec.rb
+++ b/spec/device_wizard/os_details_spec.rb
@@ -53,7 +53,7 @@ describe DeviceWizard::UserAgentDetector do
       user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2"
       os = subject.get_os(user_agent)
       expect(os.name).to eq('Mac OSX')
-      expect(os.version).to eq('10.6')
+      expect(os.version).to eq('10.6.8')
     end
 
   end


### PR DESCRIPTION
Given the following two user agents

chrome_mac = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36"
firefox_mac = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:71.0) Gecko/20100101 Firefox/71.0"

the version currently returns as follows
"10_1"
nil

10.1 is obviously misleading, but more importantly firefox returns nil (this actually results as an error see: https://github.com/Sage/device_wizard/issues/7)

this PR fixes the regex of the mac resolver to make the agents return the following
"10_14_5"
"10.14"

which when later gsubb'ed will provide a more accurate and consistant reporting (and not raise errors).