### PR TITLE
Remove dependency on bundler

### DIFF
--- a/device_wizard.gemspec
+++ b/device_wizard.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'simplecov'


### PR DESCRIPTION
Travis was failing due to incompatible bundler versions. This gem does not explicitly require bundler so removing it from the gemspec